### PR TITLE
Allow access to multiple members with the same type

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ using TestFoo = ::accessor::FunctionWrapper<Test, void>;
 using TestFooBar = ::accessor::MemberWrapper<Test, int>;
 ```
 
-Both ways are equal. `FunctionWrapper` takes types `<BaseClass, FunctionReturnType, FunctionArgsTypes...>`
+Accessing multiple members with the same type is only possible with the definition of a struct.
+`FunctionWrapper` takes types `<BaseClass, FunctionReturnType, FunctionArgsTypes...>`
 `MemberWrapper` works similar to `FunctionWrapper` it takes types `<BaseClass, MemberType>`
 
 Then __explicit template instantantion__ of created type `TestFoo` and `TestFooBar` shall be used 

--- a/examples/access_member.cpp
+++ b/examples/access_member.cpp
@@ -12,12 +12,14 @@ struct Dummy
 class Test
 {
   int mFoo {1};
+  int mFoo2 {2};
   std::string mBar {"Hello World"};
   Dummy mFooBar;
   std::vector<int> mVec;
 };
 
 MEMBER_ACCESSOR(TestFoo, Test, mFoo, int)
+MEMBER_ACCESSOR(TestFoo2, Test, mFoo2, int)
 MEMBER_ACCESSOR(TestBar, Test, mBar, std::string)
 MEMBER_ACCESSOR(TestFooBar, Test, mFooBar, Dummy)
 MEMBER_ACCESSOR(TestVec, Test, mVec, std::vector<int>)
@@ -35,6 +37,9 @@ int main()
 
   std::cout << "\nmFoo             : "
             << accessor::accessMember<TestFoo>(t) << '\n';
+
+  std::cout << "\nmFoo2             : "
+            << accessor::accessMember<TestFoo2>(t) << '\n';
 
   std::cout << "\nmBar             : "
             << accessor::accessMember<TestBar>(t).get() << '\n';

--- a/include/accessor/accessor.hpp
+++ b/include/accessor/accessor.hpp
@@ -74,15 +74,15 @@ namespace accessor
   accessor::ConstFunctionWrapper<__VA_ARGS__>
 
 #define FUNCTION_ACCESSOR(accessor_name, base, method, ...)            \
-  using accessor_name = FUNCTION_HELPER(base, __VA_ARGS__);            \
+  struct accessor_name : FUNCTION_HELPER(base, __VA_ARGS__) {};            \
   template class accessor::MakeProxy<accessor_name, &base::method>;
 
 #define CONST_FUNCTION_ACCESSOR(accessor_name, base, method, ...)      \
-  using accessor_name = CONST_FUNCTION_HELPER(base, __VA_ARGS__);      \
+  struct accessor_name : CONST_FUNCTION_HELPER(base, __VA_ARGS__) {};      \
   template class accessor::MakeProxy<accessor_name, &base::method>;
 
 #define MEMBER_ACCESSOR(accessor_name, base, member, ret_type)         \
-  using accessor_name = accessor::MemberWrapper<base, ret_type>;       \
+  struct accessor_name : accessor::MemberWrapper<base, ret_type> {};       \
   template class accessor::MakeProxy<accessor_name, &base::member>;
 
 #endif // ACCESSOR_INCLUDE_ACCESSOR_HPP


### PR DESCRIPTION
- Change macros to define a valid tag with `struct` instead of `using`
- Added some tests
- README changed