### PR TITLE
Fix examples compilation issue

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -1,7 +1,10 @@
 name: Build & Test
+
 on:
-  push: { branches: [ main, master ] }
+  push:
+    branches: [ main, master ]
   pull_request: {}
+
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
@@ -9,12 +12,80 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        std: [14, 20, 23]
+        compiler: [gcc, clang]
+        exclude:
+          # macOS: Apple Clang only
+          - os: macos-latest
+            compiler: gcc
+          # Windows: use MSVC only
+          - os: windows-latest
+            compiler: gcc
+          - os: windows-latest
+            compiler: clang
+
+    name: ${{ matrix.os }} | C++${{ matrix.std }} | ${{ matrix.compiler }}
+
     steps:
       - uses: actions/checkout@v4
       - uses: seanmiddleditch/gha-setup-ninja@v5
+
+      - name: Setup compiler
+        run: |
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            if [[ "${{ matrix.compiler }}" == "gcc" ]]; then
+              sudo apt update -y
+              sudo apt install -y g++-11
+              echo "CXX=g++-11" >> $GITHUB_ENV
+            else
+              sudo apt update -y
+              sudo apt install -y clang-15
+              echo "CXX=clang++-15" >> $GITHUB_ENV
+            fi
+          elif [[ "${{ runner.os }}" == "macOS" ]]; then
+            # Apple Clang is preinstalled and modern (LLVM-based)
+            echo "CXX=clang++" >> $GITHUB_ENV
+          else
+            # Windows automatically uses MSVC via CMake
+            echo "Using MSVC on Windows"
+          fi
+
+      - name: Print compiler info
+        run: |
+          cmake --version
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            cl
+          else
+            $CXX --version
+          fi
+
       - name: Configure
-        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
+        run: |
+          if [[ "${{ matrix.compiler }}" == "gcc" ]]; then
+            CMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror -Wno-array-bounds"
+          else
+            CMAKE_CXX_FLAGS="-Wall -Wextra -Wpedantic -Werror"
+          fi
+          cmake -S . -B build -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_CXX_STANDARD=${{ matrix.std }} \
+          -DCMAKE_CXX_STANDARD_REQUIRED=ON \
+          -DBUILD_TESTING=ON \
+          -DEXAMPLES=ON \
+          -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS"
+
       - name: Build
         run: cmake --build build --parallel
-      - name: Test
+
+      - name: Run tests
         run: ctest --test-dir build --output-on-failure
+
+      - name: Run examples
+        if: runner.os == 'Linux'
+        run: |
+          if [ -d build/examples ]; then
+            echo "Running examples..."
+            find build/examples -maxdepth 1 -type f -executable -print -exec {} \;
+          else
+            echo "No examples directory found."
+          fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,19 +41,34 @@ endif()
 
 #TESTS
 enable_testing()
-add_executable(functionWrapperTestSuite tests/functionWrapperTestSuite.cpp)
-target_link_libraries(functionWrapperTestSuite accessor)
+include(CTest)
 
-add_executable(memberWrapperTestSuite tests/memberWrapperTestSuite.cpp)
-target_link_libraries(memberWrapperTestSuite accessor)
+set(TEST_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/tests/test_utils)
 
-add_executable(callFunctionTestSuite tests/callFunctionTestSuite.cpp)
-target_link_libraries(callFunctionTestSuite accessor)
+set(TEST_SOURCES
+    tests/functionWrapperTestSuite.cpp
+    tests/memberWrapperTestSuite.cpp
+    tests/callFunctionTestSuite.cpp
+    tests/accessMemberTestSuite.cpp
+)
 
-add_executable(accessMemberTestSuite tests/accessMemberTestSuite.cpp)
-target_link_libraries(accessMemberTestSuite accessor)
+foreach(test_src ${TEST_SOURCES})
+    get_filename_component(test_name ${test_src} NAME_WE)
+    add_executable(${test_name} ${test_src})
+    target_link_libraries(${test_name} PRIVATE accessor)
+    target_include_directories(${test_name} PRIVATE ${TEST_INCLUDE_DIR})
 
-add_test(functionWrapperTests functionWrapperTestSuite)
-add_test(memberWrapperTests memberWrapperTestSuite)
-add_test(callFunctionTest callFunctionTestSuite)
-add_test(accessMemberTest accessMemberTestSuite)
+    if(MSVC)
+        target_compile_options(${test_name} PRIVATE /W4 /WX)
+    else()
+        target_compile_options(${test_name} PRIVATE -Wall -Wextra -Werror)
+
+         # Suppress known GCC false positive on -Warray-bounds
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            target_compile_options(${test_name} PRIVATE -Wno-array-bounds)
+        endif()
+    endif()
+
+
+    add_test(NAME ${test_name} COMMAND ${test_name})
+endforeach()

--- a/README.md
+++ b/README.md
@@ -187,6 +187,27 @@ int main()
 }
 ```
 
+## GCC warning note
+
+When building with GCC 10 or newer, you might encounter a false-positive diagnostic similar to:
+
+```
+error: array subscript ‘int (**)(...)[0]’ is partly outside array bounds [...]
+```
+
+This originates from an over-aggressive `-Warray-bounds` check introduced in GCC 10, which can be triggered by
+template-based or pointer-to-member expressions used internally by this library.
+
+This is not a real issue and does not indicate undefined behavior. It is a known GCC false positive
+(see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107699).
+
+To prevent example or test builds from failing when compiling with
+`-Wall -Wextra -Wpedantic -Werror`, this specific warning can be safely suppressed using:
+
+```bash
+-Wno-array-bounds
+```
+
 ## License
 
 [MIT License](https://github.com/hliberacki/cpp-member-accessor/blob/master/LICENSE)

--- a/examples/access_function.cpp
+++ b/examples/access_function.cpp
@@ -13,43 +13,47 @@ class Test
 
   void bar(int i, double d)
   {
-    std::cout << "private method: Bar. Args:[" << i << ", " << d << "]"<< '\n';
+    std::cout << "private method: Bar. Args:[" << i << ", " << d << "]" << '\n';
   }
 
-  int getSum(int first, int second ) const { return first + second; }
+  int getSum(int first, int second) const { return first + second; }
 
-  template<typename T>
-  T max(T& lhs, T& rhs) { return (lhs > rhs) ? lhs : rhs; }
+  template <typename T>
+  T max(T &lhs, T &rhs) { return (lhs > rhs) ? lhs : rhs; }
 };
 
 FUNCTION_ACCESSOR(TestFoo, Test, foo, void)
 FUNCTION_ACCESSOR(TestBar, Test, bar, void, int, double)
 CONST_FUNCTION_ACCESSOR(TestSum, Test, getSum, int, int, int)
 
-FUNCTION_ACCESSOR(TestMaxInt, Test, max, int, int&, int&)
-FUNCTION_ACCESSOR(TestMaxFloat, Test, max, float, float&, float&)
+FUNCTION_ACCESSOR(TestMaxInt, Test, max, int, int &, int &)
+FUNCTION_ACCESSOR(TestMaxFloat, Test, max, float, float &, float &)
 
 int main()
 {
   Test t;
+  auto a = 20;
+  auto b = 30;
+  auto x = 0.7f;
+  auto y = 0.5f;
 
   std::cout << "\nfoo()                 : ";
   accessor::callFunction<TestFoo>(t);
 
   std::cout << "\nbar(20, 30)           : ";
-  accessor::callFunction<TestBar>(t, 20, 30);
+  accessor::callFunction<TestBar>(t, a, b);
 
   std::cout << "\ngetSum(20, 30)        : ";
-  auto result = accessor::callFunction<TestSum>(t, 20, 30);
+  auto result = accessor::callFunction<TestSum>(t, a, b);
   std::cout << "sum output: " << result << '\n';
 
   std::cout << "\nmax<int>(20, 30)      : ";
-  auto maxInt = accessor::callFunction<TestMaxInt>(t, 20, 30);
-  std::cout  << maxInt << '\n';
+  auto maxInt = accessor::callFunction<TestMaxInt>(t, a, b);
+  std::cout << maxInt << '\n';
 
   std::cout << "\nmax<float>(0.7f, 0.5f): ";
-  auto maxFloat = accessor::callFunction<TestMaxFloat>(t, 0.7f, 0.5f);
-  std::cout  << maxFloat << '\n';
+  auto maxFloat = accessor::callFunction<TestMaxFloat>(t, x, y);
+  std::cout << maxFloat << '\n';
 
   return 0;
 }

--- a/examples/no_macro.cpp
+++ b/examples/no_macro.cpp
@@ -13,27 +13,27 @@ class Test
 
   void bar(int i, double d)
   {
-    std::cout << "private method: Bar. Args:[" << i << ", " << d << "]"<< '\n';
+    std::cout << "private method: Bar. Args:[" << i << ", " << d << "]" << '\n';
   }
 
-  int getSum(int first, int second ) const { return first + second; }
+  int getSum(int first, int second) const { return first + second; }
 
-  template<typename T>
-  T max(T& lhs, T& rhs) { return (lhs > rhs) ? lhs : rhs; }
+  template <typename T>
+  T max(T &lhs, T &rhs) { return (lhs > rhs) ? lhs : rhs; }
 
-  int mFooBar {1};
+  int mFooBar{1};
 };
 
-using TestFoo      = accessor::FunctionWrapper<Test, void>;
-using TestBar      = accessor::FunctionWrapper<Test, void, int, double>;
-using TestSum      = accessor::ConstFunctionWrapper<Test, int, int, int>;
-using TestMaxInt   = accessor::FunctionWrapper<Test, int, int&, int&>;
-using TestMaxFloat = accessor::FunctionWrapper<Test, float, float&, float&>;
+using TestFoo = accessor::FunctionWrapper<Test, void>;
+using TestBar = accessor::FunctionWrapper<Test, void, int, double>;
+using TestSum = accessor::ConstFunctionWrapper<Test, int, int, int>;
+using TestMaxInt = accessor::FunctionWrapper<Test, int, int &, int &>;
+using TestMaxFloat = accessor::FunctionWrapper<Test, float, float &, float &>;
 
-template<typename T>
-using TestMax      = accessor::FunctionWrapper<Test, T, T&, T&>;
+template <typename T>
+using TestMax = accessor::FunctionWrapper<Test, T, T &, T &>;
 
-using TestFooBar   = accessor::MemberWrapper<Test, int>;
+using TestFooBar = accessor::MemberWrapper<Test, int>;
 
 template class accessor::MakeProxy<TestFoo, &Test::foo>;
 template class accessor::MakeProxy<TestBar, &Test::bar>;
@@ -47,27 +47,40 @@ int main()
 {
   Test t;
 
-  std::cout << "\nfoo()                  : ";
-  accessor::callFunction<TestFoo>(t);
+  {
+    auto a = 20;
+    auto b = 30;
 
-  std::cout << "\nbar(20, 30)            : ";
-  accessor::callFunction<TestBar>(t, 20, 30);
+    std::cout << "\nfoo()                  : ";
+    accessor::callFunction<TestFoo>(t);
 
-  std::cout << "\ngetSum(20, 30)         : ";
-  auto result = accessor::callFunction<TestSum>(t, 20, 30);
-  std::cout << "sum output: " << result << '\n';
+    std::cout << "\nbar(20, 30)            : ";
+    accessor::callFunction<TestBar>(t, a, b);
 
-  std::cout << "\nmax<int>(20, 30)       : ";
-  auto maxInt = accessor::callFunction<TestMaxInt>(t, 20, 30);
-  std::cout  << maxInt << '\n';
+    std::cout << "\ngetSum(20, 30)         : ";
+    auto result = accessor::callFunction<TestSum>(t, a, b);
+    std::cout << "sum output: " << result << '\n';
 
-  std::cout << "\nmax<float>(0.7f, 0.5f) : ";
-  auto maxFloat = accessor::callFunction<TestMaxFloat>(t, 0.7f, 0.5f);
-  std::cout  << maxFloat << '\n';
+    std::cout << "\nmax<int>(20, 30)       : ";
+    auto maxInt = accessor::callFunction<TestMaxInt>(t, a, b);
+    std::cout << maxInt << '\n';
+  }
 
-  std::cout << "\nmax<double>(0.37, 0.56): ";
-  auto maxDouble = accessor::callFunction<TestMax<double>>(t, 0.37, 0.56);
-  std::cout  << maxDouble << '\n';
+  {
+    auto a = 0.7f;
+    auto b = 0.5f;
+    std::cout << "\nmax<float>(0.7f, 0.5f) : ";
+    auto maxFloat = accessor::callFunction<TestMaxFloat>(t, a, b);
+    std::cout << maxFloat << '\n';
+  }
+
+  {
+    auto a = 0.37;
+    auto b = 0.56;
+    std::cout << "\nmax<double>(0.37, 0.56): ";
+    auto maxDouble = accessor::callFunction<TestMax<double>>(t, a, b);
+    std::cout << maxDouble << '\n';
+  }
 
   std::cout << "\nmFooBar                : " << accessor::accessMember<TestFooBar>(t)
             << '\n';

--- a/tests/callFunctionTestSuite.cpp
+++ b/tests/callFunctionTestSuite.cpp
@@ -40,14 +40,14 @@ private:
 
   void foo() { incrementMethodVisitedCounter("foo"); }
 
-  int getSum(int first, int second )
+  int getSum(int first, int second)
   {
     incrementMethodVisitedCounter("getSum");
     return first + second;
   }
 
-  template<typename T>
-  T max(T& lhs, T& rhs)
+  template <typename T>
+  T max(T &lhs, T &rhs)
   {
     incrementMethodVisitedCounter("max");
     return (lhs > rhs) ? lhs : rhs;
@@ -55,7 +55,6 @@ private:
 
   std::map<std::string, int> mVisitedMethods;
 };
-
 
 using TestFoo = ::accessor::FunctionWrapper<Test, void>;
 template class ::accessor::MakeProxy<TestFoo, &Test::foo>;
@@ -72,7 +71,7 @@ bool callMultipleSimpleFoo()
   Test t;
   int callsNumber = 10;
 
-  for (int i = 0; i < callsNumber; ++i )
+  for (int i = 0; i < callsNumber; ++i)
   {
     ::accessor::callFunction<TestFoo>(t);
   }
@@ -107,8 +106,8 @@ bool callMultipleGetSum()
   return testResult;
 }
 
-template<typename T>
-using TestMax = ::accessor::FunctionWrapper<Test, T, T&, T&>;
+template <typename T>
+using TestMax = ::accessor::FunctionWrapper<Test, T, T &, T &>;
 template class ::accessor::MakeProxy<TestMax<int>, &Test::max>;
 template class ::accessor::MakeProxy<TestMax<uint32_t>, &Test::max>;
 
@@ -119,7 +118,7 @@ bool calOnceTemplatedMax()
 
   {
     int a = 10, b = 20;
-    testResult = (::accessor::callFunction<TestMax<int>>(t, a, b) == 20);
+    testResult = (::accessor::callFunction<TestMax<int>>(t, a, b) == 20) &&
                  (t.getMethodVisitedCounter("max") > 0);
   }
 
@@ -131,7 +130,6 @@ bool calOnceTemplatedMax()
 
   return testResult;
 }
-
 
 bool calMultipleTemplatedMax()
 {

--- a/tests/memberWrapperTestSuite.cpp
+++ b/tests/memberWrapperTestSuite.cpp
@@ -5,15 +5,16 @@
 // Project home: https://github.com/hliberacki/cpp-member-accessor
 
 #include "test_helper.hpp"
+#include "test_utils/compiler_attributes.hpp"
 #include <accessor/accessor.hpp>
 #include <iostream>
 #include <vector>
 
 class Test
 {
-  int mFoo;
-  const float mBar;
-  std::vector<int> mFooBar;
+  UNUSED int mFoo;
+  UNUSED const float mBar{3.14f};
+  UNUSED std::vector<int> mFooBar;
 };
 
 bool checkSignatureBasic()

--- a/tests/test_utils/compiler_attributes.hpp
+++ b/tests/test_utils/compiler_attributes.hpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) 2017-2025 Hubert Liberacki <hliberacki@gmail.com>
+//
+// cpp-member-accessor – header-only C++ library for accessing private members
+// Project home: https://github.com/hliberacki/cpp-member-accessor
+
+#ifndef ACCESSOR_TESTS_TESTS_UTILS_COMPILER_ATTRIBUTES_HPP
+#define ACCESSOR_TESTS_TESTS_UTILS_COMPILER_ATTRIBUTES_HPP
+
+#if __cplusplus >= 201703L
+#define UNUSED [[maybe_unused]]
+#elif defined(__clang__)
+#define UNUSED __attribute__((unused))
+#elif defined(__GNUC__)
+#define UNUSED
+#else
+#define UNUSED
+#endif
+
+#endif // ACCESSOR_TESTS_TESTS_UTILS_COMPILER_ATTRIBUTES_HPP


### PR DESCRIPTION
After adding perfect forwarding - some examples where not updated that made them crash

- Extend CI to build examples

Extended CI job to build examples

- Extend CI to test on various C++ version

CI now build the code using C++ [14, 20, 23], using [gcc, clang, msvc] running on Windows, Linux, MacOS